### PR TITLE
Refreshed the RVM instructions

### DIFF
--- a/app/views/install_steps/install_rvm_and_ruby.html.erb
+++ b/app/views/install_steps/install_rvm_and_ruby.html.erb
@@ -5,44 +5,16 @@
   <hr>
   <ol>
     <li>To install RVM, type this in your terminal</li>
-    <pre><code>curl -L https://get.rvm.io | bash -s stable</code></pre>
+    <pre><code>\curl -L https://get.rvm.io | bash -s stable</code></pre>
 
-    <li>Close your terminal and then re-open it. Now, let's load RVM and make sure the terminal remembers to do the same next time:
-      <pre><code>source ~/.rvm/scripts/rvm
-touch .bash_profile
-open .bash_profile</code></pre>
-      <div class="row">
-            <div class="col-sm-12 note">
-              <strong>Note:</strong> If a .profile already exists, you can open that instead
-            </div>
-          </div>
-    <p>Paste the following into your new .bash_profile then save and close it:</p>
-    <pre><code>PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
-
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm" # Load RVM function</pre></code>
+    <li>Close your terminal and then re-open it. Now, lets see if RVM was loaded properly:
+      <pre><code>type rvm | head -n 1</code></pre>
     </li>
     <li>Now install Ruby with:
-      <pre><code>rvm install 2.0.0
-rvm use 2.0.0 --default
+      <pre><code>rvm use ruby --install --default
 ruby -v</code></pre>
-
-      <div class="row">
-      <div class="col-sm-12 note">
-        <h3>Notes:</h3>
-        <ul>
-          <li>This will install Ruby and may take a while.</li>
-          <li>If you get an entire page of instructions, beginning with 'Ruby (and needed base gems) for your selection...', you should press Q to skip.</li>
-          <li>If RVM reports an error, run:
-            <pre><code>rvm requirements</code></pre>
-            <p>Any "Missing Required Package" statements can be resolved by entering
-              <pre><code>brew install *missing package name*
-EX:
-$ brew install autoconf automake libtool pkg-config apple-gcc42 libyaml readline libxml2 libxslt libksba openssl sqlite imagemagick</pre></code>
-            </p>
-          </li>
-        </ul>
-      </div>
-    </div>
+      <p>This will install Ruby and may take a while, on older OSX it might take up to 1 hour.</p>
+    </li>
 
   </ol>
 </section>


### PR DESCRIPTION
removed lots of not needed code that was relevant for old RVM versions only ... there might be note missing explaining to "read the printed instructions"
