### PR TITLE
More explicit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ bundle install
 rails server
 ```
 
-Open http://localhost:3000` in your browser.
+Open http://localhost:3000 in your browser.


### PR DESCRIPTION
Running `open http://localhost:3000` would certainly work if the user opened up a new terminal window but won't do anything if it's run immediately after starting the Rails server, which might confuse people new to the command line. I broke it out of code brackets and added an explanatory sentence.
