### PR TITLE
added install Ruby with rbenv for OS X 10.10 & 10.9

### DIFF
--- a/app/assets/stylesheets/_install_steps.scss
+++ b/app/assets/stylesheets/_install_steps.scss
@@ -84,7 +84,7 @@ section {
   padding: 1.7em;
 }
 
-.find_the_command_line, .install_rvm_and_ruby {
+.find_the_command_line, .install_rvm_and_ruby, .install_rbenv_and_ruby {
   background-color: #3B4960;
 
   .note:before {

--- a/app/controllers/install_steps_controller.rb
+++ b/app/controllers/install_steps_controller.rb
@@ -57,6 +57,7 @@ class InstallStepsController < ApplicationController
           :configure_git,
           :install_rvm_and_ruby,
           :install_rails,
+          :install_rbenv_and_ruby,
           text_editor_step,
           :create_your_first_app,
           :see_it_live]

--- a/app/views/install_steps/install_rbenv_and_ruby.html.erb
+++ b/app/views/install_steps/install_rbenv_and_ruby.html.erb
@@ -1,0 +1,31 @@
+<section class="instructions">
+  <h1>Install rbenv and Ruby (OPTIONAL)</h1>
+  <p class="center">In contrast with RVM, rbenv is an alternative solution. This is not recommended for OSX 10.5 or below</p>
+  <hr>
+  <ol>
+    <li>To install rbenv, type this in your terminal</li>
+
+      <pre><code>brew install rbenv ruby-build</code></pre>
+
+    <li>Now install Ruby with:</li>
+
+      <pre><code>rbenv install 2.2.x
+rbenv global 2.2.x
+ruby -v</code></pre>
+    
+    <li>Now install Rails with:</li>
+
+      <pre><code>gem install rails -v 4.2.x</code></pre>
+
+    <li>Rails is now installed, but in order for us to use the <code>rails</code> executable, you need to tell <code>rbenv</code> to see it.</li>
+
+      <pre><code>rbenv rehash</code></pre>
+    
+  </ol>
+</section>
+
+<%= render 'layouts/step_navigation' %>
+
+<div id="trouble" class="collapse out note">
+  <%= render 'layouts/disqus' %>
+</div>


### PR DESCRIPTION
I've been using rbenv instead of rvm. I thought it would be helpful to others to include an "install Ruby with rbenv page." The install instructions are taken from GoRails' "Setup Rails" page.