### PR TITLE
Update OS X instructions

### DIFF
--- a/app/controllers/install_steps_controller.rb
+++ b/app/controllers/install_steps_controller.rb
@@ -47,7 +47,7 @@ class InstallStepsController < ApplicationController
           text_editor_step,
           :create_your_first_app,
           :see_it_live]
-      when "10.10", "10.9", "10.5 or below"
+      when "10.10", "10.9"
         [ :choose_os,
           :choose_os_version,
           :install_xcode,
@@ -74,10 +74,7 @@ class InstallStepsController < ApplicationController
     end
 
     def text_editor_step
-      case os_version
-      when /10.5/ then :textmate
-      else :sublime_text
-      end
+       :sublime_text
     end
 
     def finish_wizard_path

--- a/app/controllers/install_steps_controller.rb
+++ b/app/controllers/install_steps_controller.rb
@@ -47,7 +47,7 @@ class InstallStepsController < ApplicationController
           text_editor_step,
           :create_your_first_app,
           :see_it_live]
-      when "10.10", "10.9"
+      when "10.11", "10.10", "10.9"
         [ :choose_os,
           :choose_os_version,
           :install_xcode,

--- a/app/views/install_steps/choose_os_version.html.erb
+++ b/app/views/install_steps/choose_os_version.html.erb
@@ -15,10 +15,11 @@
     Select your version of <%= current_user.os %> OS X
   </h2>
   <div class="options">
+    <%= button_to "10.11", wizard_path, name: :os_version, method: :put, class: "option" %>
     <%= button_to "10.10", wizard_path, name: :os_version, method: :put, class: "option" %>
     <%= button_to "10.9", wizard_path, name: :os_version, method: :put, class: "option" %>
-    <%= button_to "10.8", wizard_path, name: :os_version, method: :put, class: "option" %>
     <br>
+    <%= button_to "10.8", wizard_path, name: :os_version, method: :put, class: "option" %>
     <%= button_to "10.7", wizard_path, name: :os_version, method: :put, class: "option" %>
     <%= button_to "10.6", wizard_path, name: :os_version, method: :put, class: "option" %>
     <br>

--- a/app/views/install_steps/choose_os_version.html.erb
+++ b/app/views/install_steps/choose_os_version.html.erb
@@ -1,5 +1,5 @@
 <section class="instructions">
-  <h1>What version of Mac OS do you have?</h1>
+  <h1>What version of OS X do you have?</h1>
   <ol>
     <li>
       <p>Click on the &#63743; <strong>Apple</strong> logo (at the top left of your screen)<br>and select '<strong>About This Mac</strong>'</p>
@@ -12,7 +12,7 @@
 
 <div class="prompt center">
   <h2>
-    Select your version of <%= current_user.os %> OS X
+    Select your version of OS X
   </h2>
   <div class="options">
     <%= button_to "10.11", wizard_path, name: :os_version, method: :put, class: "option" %>

--- a/app/views/install_steps/choose_os_version.html.erb
+++ b/app/views/install_steps/choose_os_version.html.erb
@@ -21,7 +21,6 @@
     <br>
     <%= button_to "10.7", wizard_path, name: :os_version, method: :put, class: "option" %>
     <%= button_to "10.6", wizard_path, name: :os_version, method: :put, class: "option" %>
-    <%= button_to "10.5 or below", wizard_path, name: :os_version, method: :put, class: "option" %>
     <br>
     <%= button_tag "Troubleshooting", type: "button", class: "troubleshooting", data: {toggle: "collapse", target: "#trouble"} %>
   </div>

--- a/app/views/install_steps/install_rvm_and_ruby.html.erb
+++ b/app/views/install_steps/install_rvm_and_ruby.html.erb
@@ -15,7 +15,7 @@
     <li>Now install Ruby with:
       <pre><code>rvm use ruby --install --default
 ruby -v</code></pre>
-      <p>This will install Ruby and may take a while, on older OSX it might take up to 1 hour.</p>
+      <p>This will install Ruby and may take a while, on older versions of OS X it might take up to 1 hour.</p>
     </li>
   </ol>
 </section>

--- a/app/views/install_steps/install_xcode.html.erb
+++ b/app/views/install_steps/install_xcode.html.erb
@@ -2,11 +2,7 @@
   <h1>Install Xcode</h1>
   <ol>
     <li>
-      Open the Mac App Store. This can be found in your Applications Folder.
-      <%= image_tag "xcode_finder.png", class: "list-image" %>
-    </li>
-    <li>
-      Search for “Xcode” and click the “Install” button
+      Install <a href="https://itunes.apple.com/app/id497799835?mt=12">Xcode from the Mac App Store</a>.
      <div class="row">
         <div class="col-sm-12 note">
          <strong>Assuming Xcode has finished installing:</strong> Now you can check the Command Line Tools.


### PR DESCRIPTION
Updates the instructions to remove references to OS X 10.5, which is now very old and isn’t being actively supported by Apple or the Homebrew project (the instructions wouldn’t even have helped as the Mac App Store was introduced with 10.6.6).

Arguably the minimum OS X version could and should be pushed even higher. The [Homebrew installation guide](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md) says:

>10.9 or higher is recommended. 10.5 - 10.8 are supported on a best-effort basis. For 10.4 and 10.5, see Tigerbrew.