### PR TITLE
Format HTML code in ERB views && Update console outputs to the new Rails 5.2.x

### DIFF
--- a/app/views/install_steps/install_rails.html.erb
+++ b/app/views/install_steps/install_rails.html.erb
@@ -8,44 +8,39 @@
     <li>
       To verify your installation, in your terminal type
     </li>
-      <pre><code>rails --version</code></pre>
-      <p>Approximate expected result</p>
-      <pre><code>Rails 5.1.x</code></pre>
+    <pre><code>rails --version</code></pre>
+    <p>Approximate expected result</p>
+    <pre><code>Rails 5.2.x</code></pre>
   </ol>
   <div class="row">
-      <div class="col-sm-12 note">
-        <h3>Notes:</h3>
-        <ul>
-          <li>This will install Rails and may take a while.</li>
-          <li>If Rails cannot install, check the failure message. if it contains:
-          <pre><code>
-          -----
-          libxml2 is missing.  Please locate mkmf.log to investigate how it is failing.
-          -----
-          </code></pre>
+    <div class="col-sm-12 note">
+      <h3>Notes:</h3>
+      <ul>
+        <li>This will install Rails and may take a while.</li>
+        <li>If Rails cannot install, check the failure message. if it contains:
+          <pre><code>-----
+libxml2 is missing.  Please locate mkmf.log to investigate how it is failing.
+-----</code></pre>
           and you are using OS X 10.10 or later, then run:
-          <pre><code>
-          brew install libxml2
-          env ARCHFLAGS="-arch x86_64" gem install nokogiri:1.6.4.1 -- --use-system-libraries --with-xml=/usr/local/Cellar/libxml2/
-          </code></pre>
-          to install libxml2 and nokogiri and rerun the rails instalation.
+          <pre><code>brew install libxml2
+env ARCHFLAGS="-arch x86_64" gem install nokogiri:1.6.4.1 -- --use-system-libraries --with-xml=/usr/local/Cellar/libxml2/</code></pre>
+        to install libxml2 and nokogiri and rerun the rails instalation.
           <p>Else, try running the code below and then restarting your computer:
             <pre><code>brew install apple-gcc42</code></pre>
-            </p>
-
-            <p>If you are still stuck, try:
-              <pre><code>sudo xcodebuild -license
+          </p>
+          <p>If you are still stuck, try:
+            <pre><code>sudo xcodebuild -license
 sudo port upgrade outdated
 rvm reinstall 2.4.1</pre></code>
-            </p>
-          </li>
-        </ul>
-      </div>
+          </p>
+        </li>
+      </ul>
     </div>
+  </div>
 </section>
 
 <%= render 'layouts/step_navigation' %>
 
 <div id="trouble" class="collapse out note">
-    <%= render 'layouts/disqus' %>
+  <%= render 'layouts/disqus' %>
 </div>

--- a/app/views/install_steps/see_it_live.html.erb
+++ b/app/views/install_steps/see_it_live.html.erb
@@ -11,31 +11,31 @@
     </li>
     <li>
       This command should show you:
-      <pre><code>=> Booting WEBrick
-=> Rails 4.0.0 application starting in development on http://0.0.0.0:3000
+      <pre><code>=> Booting Puma
+=> Rails 5.2.0 application starting in development
 => Run `rails server -h` for more startup options
-=> Ctrl-C to shutdown server
-[2013-08-01 16:37:03] INFO  WEBrick 1.3.1
-[2013-08-01 16:37:03] INFO  ruby 2.0.0 (2013-05-14) [x86_64-darwin12.4.0]
-[2013-08-01 16:37:03] INFO  WEBrick::HTTPServer#start: pid=12109 port=3000</code></pre>
+Puma starting in single mode...
+* Version 3.11.4 (ruby 2.5.1-p57), codename: Love Song
+* Min threads: 5, max threads: 5
+* Environment: development
+* Listening on tcp://0.0.0.0:3000
+Use Ctrl-C to stop</code></pre>
     </li>
+    <li>
+      Open up your browser and visit <%= link_to "http://localhost:3000", "http://localhost:3000", target: "_blank" %>
+    </li>
+  </ol>
+  <p>You should see your new web app!</p>
+  <hr>
 
-        <li>
-          Open up your browser and visit <%= link_to "http://localhost:3000", "http://localhost:3000", target: "_blank" %>
-        </li>
-      </ol>
-      <p>You should see your new web app!</p>
-       <hr>
-
-     <div class="row">
-            <div class="col-sm-6 note">
-            PRO TIP:<br>Whenever you run <pre><code>$ rails server</pre></code> …you’ll no longer be able to type anything in that command line window (because that window is now busy running your site).<br><br>Leaving us with two options:<br>1) When you’re coding: let this window run the server, and open another command line window to write new commands<br>2) When you’re finished: close the server by hitting “<strong>Control + C</strong>” and give yourself a pat on the back for being awesome.
-          </div>
-           <div class="col-sm-6">
-            <%= image_tag "sam.png", class: 'sam' %>
-          </div>
-
+  <div class="row">
+    <div class="col-sm-6 note">
+      PRO TIP:<br>Whenever you run <pre><code>$ rails server</pre></code> …you’ll no longer be able to type anything in that command line window (because that window is now busy running your site).<br><br>Leaving us with two options:<br>1) When you’re coding: let this window run the server, and open another command line window to write new commands<br>2) When you’re finished: close the server by hitting “<strong>Control + C</strong>” and give yourself a pat on the back for being awesome.
     </div>
+    <div class="col-sm-6">
+      <%= image_tag "sam.png", class: 'sam' %>
+    </div>
+  </div>
 </section>
 
 <%= render 'layouts/step_navigation' %>


### PR DESCRIPTION
I just have updated two outputs from the console when running this two commands in the corresponding steps to show the most recent Rails version 5.2.1 at this time according to https://rubyonrails.org:

- install_rails.html.erb

  Updated the new output from console when running: `rails --version`
  ```sh
  Rails 5.2.0
  ```

  > Before
  ![screen shot 2018-10-11 at 12 54 59](https://user-images.githubusercontent.com/13169164/46823913-17340700-cd55-11e8-8712-25d208270598.png)
  > After
  ![screen shot 2018-10-11 at 12 29 48](https://user-images.githubusercontent.com/13169164/46823914-17340700-cd55-11e8-985f-fbc4aeddcfe0.png)

- see_it_live.html.erb

  Updated the new output from console when running: `rails server`
  ```sh
  => Booting Puma
  => Rails 5.2.0 application starting in development
  => Run `rails server -h` for more startup options
  Puma starting in single mode...
  * Version 3.11.4 (ruby 2.5.1-p57), codename: Love Song
  * Min threads: 5, max threads: 5
  * Environment: development
  * Listening on tcp://0.0.0.0:3000
  Use Ctrl-C to stop
  ```

  > Before
  ![screen shot 2018-10-11 at 13 00 14](https://user-images.githubusercontent.com/13169164/46824199-bfe26680-cd55-11e8-8b60-9ed8468df29b.png)
  > After
  ![screen shot 2018-10-11 at 12 30 45](https://user-images.githubusercontent.com/13169164/46824196-bfe26680-cd55-11e8-9334-23c1617abf32.png)  

At the same time I have just fixed some miss indentation in the Rails views.