### PR TITLE
Remove a step that causes the app to crash in `Production`.

### DIFF
--- a/app/controllers/install_steps_controller.rb
+++ b/app/controllers/install_steps_controller.rb
@@ -60,6 +60,7 @@ class InstallStepsController < ApplicationController
       :railsinstaller_windows,
       :find_git_bash,
       :update_rubygems,
+      :update_rails,
       :sublime_text,
       :create_your_first_app,
       :see_it_live

--- a/app/controllers/install_steps_controller.rb
+++ b/app/controllers/install_steps_controller.rb
@@ -60,7 +60,6 @@ class InstallStepsController < ApplicationController
       :railsinstaller_windows,
       :find_git_bash,
       :update_rubygems,
-      :update_rails,
       :sublime_text,
       :create_your_first_app,
       :see_it_live

--- a/app/views/install_steps/update_rails.html.erb
+++ b/app/views/install_steps/update_rails.html.erb
@@ -1,0 +1,48 @@
+<% if current_user.rails_version =~ /3.2/ %>
+  <section class="instructions">
+    <h1>Because you don't have the latest version of Rails, we're going to update to the latest version</h1>
+    <ol>
+      <li>In the command line, run the following command:</li>
+      <pre><code>$ gem update rails --no-ri --no-rdoc</code></pre>
+      <p>This command should update several gems for you and may take a few minutes</p>
+      <li>
+        Next, check to see if you have Rails installed by running:
+        <pre><code>$ rails --version</code></pre>
+      </li>
+    </ol>
+  </section>
+
+  <%= render 'layouts/step_navigation' %>
+<% else %>
+  <section class="instructions">
+    <h1>Because you don't have Rails installed yet, we're going to install it</h1>
+    <ol>
+      <li>In the command line, run the following command:</li>
+      <pre><code>$ gem install rails --no-ri --no-rdoc</code></pre>
+      <p>This command should update several gems for you and may take a few minutes</p>
+      <li>
+        Next, check to see if you have the right version of Rails installed by running:
+        <pre><code>$ rails --version</code></pre>
+      </li>
+    </ol>
+  </section>
+
+  <%= render 'layouts/step_navigation' %>
+<% end %>
+
+<div id="trouble" class="collapse out note">
+  <h4>#1 - I'm currently getting an error that has the words "SSL" and "Certificate"</h4>
+  <p>If your error resembles something like...</p>
+  <pre><code>#ERROR MESSAGE:
+    Unable to download data from https://rubygems.org/ - SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (https://s3.amazonaws.com/produ...</code></pre>
+   Here are the main steps that should fix it. If not, consult this guide for a few alternative fixes: <a href="http://railsapps.github.io/openssl-certificate-verify-failed.html">OpenSSL Errors and Rails Guide</a>
+  <pre><code>$ sudo rvm osx-ssl-certs cron install
+$ brew update
+$ brew install openssl
+$ brew link openssl --force
+$ brew install curl-ca-bundle</code></pre>
+
+  <hr><br>
+
+  <%= render 'layouts/disqus' %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,20 +6,17 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43180860-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-43180860-1');
-</script>
-
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43180860-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-43180860-1');
+  </script>
   <%= yield(:head) %>
 </head>
 <body class="<%= controller_name %> <%= action_name %> <%= params[:id] %>">
-
   <%= yield(:header) %>
 
   <% if content_for? :container_override? %>
@@ -38,6 +35,5 @@
       </div>
     </footer>
   <% end %>
-
 </body>
 </html>


### PR DESCRIPTION
Actually, these are the Windows wizard steps to follow:

```ruby
def windows_steps
  [
    :railsinstaller_windows,
    :find_git_bash,
    :update_rubygems,
    :update_rails,
    :sublime_text,
    :create_your_first_app,
    :see_it_live
  ]
end
```
And the `:update_rails` step is causing the app to crash because there's no view for this since it was removed a couple of days ago in [this PR](https://github.com/onemonth/install_rails/commit/b8d8d55a2263bd0a5ca4fee7087cc492d7e83636#diff-8fd08302a662ffdd332683d41ab7a284L1).

So, I opted to remove the step too, in order to fix this issue. But if it was a mistake and we should implement that view. I can make a new PR to include both, **the step and its view**.

> Step were the app crashes in _Production_
![screen shot 2018-10-12 at 21 30 47](https://user-images.githubusercontent.com/13169164/46900342-18a12480-ce66-11e8-9cbd-0a2234fddea9.png)

> Old removed view
![screen shot 2018-10-12 at 21 20 38](https://user-images.githubusercontent.com/13169164/46900657-4d63aa80-ce6b-11e8-9863-6fd06e47cd40.png)
