### PR TITLE
Update the new command to install Rails without documentation.

### DIFF
--- a/app/views/install_steps/install_rails.html.erb
+++ b/app/views/install_steps/install_rails.html.erb
@@ -4,7 +4,7 @@
     <li>
       In your terminal type
     </li>
-    <pre><code>gem install rails --no-ri --no-rdoc</code></pre>
+    <pre><code>gem install rails --no-document</code></pre>
     <li>
       To verify your installation, in your terminal type
     </li>


### PR DESCRIPTION
In the last week I just format my HD on my MacBook Pro and install Mojave OS X from scratch. What I found when installing the newest version of `Rails 5.2.3` I tried to use the old command `gem install rails --no-ri --no-rdoc` but I got an error message as shown below:
```shell
~ gem install rails --no-ri --no-rdoc
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-ri
```
![Screen Shot 2019-04-30 at 11 58 44](https://user-images.githubusercontent.com/13169164/56979392-55511680-6b3f-11e9-9c91-9b62b9658918.png)

The I made some research and I found that the command to install Raisl without documentation has changed, the new one is this:
```shell
gem install rails --no-document
```
After using this new command, everything worked just fine!
So I think we should update this command and here are some references of what I found on my research:
- https://gitlab.com/gitlab-org/gitlab-ce/issues/55740
- https://github.com/rubygems/rubygems/pull/2354